### PR TITLE
Fix neighbouring redstone clocks making each other faster

### DIFF
--- a/src/main/java/com/fouristhenumber/utilitiesinexcess/common/blocks/BlockRedstoneClock.java
+++ b/src/main/java/com/fouristhenumber/utilitiesinexcess/common/blocks/BlockRedstoneClock.java
@@ -51,7 +51,7 @@ public class BlockRedstoneClock extends BlockContainer {
     public void onNeighborBlockChange(World world, int x, int y, int z, Block neighbor) {
         super.onNeighborBlockChange(world, x, y, z, neighbor);
 
-        if(neighbor instanceof BlockRedstoneClock) {
+        if (neighbor instanceof BlockRedstoneClock) {
             // Don't let neighbouring clocks trigger updates to each other
             return;
         }


### PR DESCRIPTION
Placing two redstone clocks adjacent to each other makes them both tick really fast which is not in line with exu behaviour.

I've addressed this by having `onNeighborBlockChange` return early if the neighbour is another redstone clock and I've confirmed this fixes the issue and does not affect the ability to turn the block off with a redstone signal.