### PR TITLE
Fix Ethereal Glass block picking

### DIFF
--- a/src/main/java/com/fouristhenumber/utilitiesinexcess/common/blocks/BlockEtherealGlass.java
+++ b/src/main/java/com/fouristhenumber/utilitiesinexcess/common/blocks/BlockEtherealGlass.java
@@ -47,6 +47,11 @@ public class BlockEtherealGlass extends BlockGlass {
     private IIcon[] icons;
 
     @Override
+    public int damageDropped(int meta) {
+        return meta;
+    }
+
+    @Override
     public void addCollisionBoxesToList(World worldIn, int x, int y, int z, AxisAlignedBB mask,
         List<AxisAlignedBB> list, Entity collider) {
         int meta = worldIn.getBlockMetadata(x, y, z);


### PR DESCRIPTION
should be self-explanatory, without this you always get a metadata of zero which returns the default variant