### PR TITLE
Fixed Trading Post Crash (Issue 142)

### DIFF
--- a/src/main/java/com/fouristhenumber/utilitiesinexcess/compat/mui/tradingpost/TradeWidget.java
+++ b/src/main/java/com/fouristhenumber/utilitiesinexcess/compat/mui/tradingpost/TradeWidget.java
@@ -13,12 +13,12 @@ import com.cleanroommc.modularui.drawable.UITexture;
 import com.cleanroommc.modularui.screen.viewport.ModularGuiContext;
 import com.cleanroommc.modularui.theme.WidgetThemeEntry;
 import com.cleanroommc.modularui.utils.Color;
+import com.cleanroommc.modularui.value.DoubleValue;
 import com.cleanroommc.modularui.value.ObjectValue;
 import com.cleanroommc.modularui.widget.ParentWidget;
 import com.cleanroommc.modularui.widget.Widget;
 import com.cleanroommc.modularui.widgets.ProgressWidget;
 import com.cleanroommc.modularui.widgets.layout.Flow;
-import com.cleanroommc.modularui.widgets.layout.Row;
 import com.fouristhenumber.utilitiesinexcess.ModItems;
 import com.fouristhenumber.utilitiesinexcess.UtilitiesInExcess;
 import com.fouristhenumber.utilitiesinexcess.compat.Mods;
@@ -72,9 +72,14 @@ public class TradeWidget extends ParentWidget<TradeWidget> implements Interactab
         itemToBuy = new TooltipItemDisplayWidget();
         itemToBuy.paddingRight(0)
             .displayAmount(true)
-            .item(new ObjectValue.Dynamic<>(() -> this.recipe != null ? this.recipe.getItemToBuy() : item, i -> {}));
+            .item(
+                new ObjectValue.Dynamic<>(
+                    ItemStack.class,
+                    () -> this.recipe != null ? this.recipe.getItemToBuy() : item,
+                    i -> {}));
 
-        Flow inputItems = new Row().childPadding(1)
+        Flow inputItems = Flow.row()
+            .childPadding(1)
             .coverChildren()
             .child(itemToBuy);
 
@@ -84,6 +89,7 @@ public class TradeWidget extends ParentWidget<TradeWidget> implements Interactab
                 .displayAmount(true)
                 .item(
                     new ObjectValue.Dynamic<>(
+                        ItemStack.class,
                         () -> this.recipe != null ? this.recipe.getSecondItemToBuy() : item,
                         i -> {}));
 
@@ -95,18 +101,23 @@ public class TradeWidget extends ParentWidget<TradeWidget> implements Interactab
 
         itemToSell = new TooltipItemDisplayWidget();
         itemToSell.displayAmount(true)
-            .item(new ObjectValue.Dynamic<>(() -> this.recipe != null ? this.recipe.getItemToSell() : item, i -> {}));
+            .item(
+                new ObjectValue.Dynamic<>(
+                    ItemStack.class,
+                    () -> this.recipe != null ? this.recipe.getItemToSell() : item,
+                    i -> {}));
 
         ProgressWidget progress = new TradeProgressWidget().direction(ProgressWidget.Direction.RIGHT)
             .texture(GuiTextures.PROGRESS_ARROW, 20)
-            .progress(() -> {
+            .value(new DoubleValue.Dynamic(() -> {
                 AccessorMerchantRecipe trade = (AccessorMerchantRecipe) getRecipe();
                 if (trade == null) return 0.69;
                 if (trade.getMaxUses() > 7) // After the initial 7 uses every recipe gets 2 to 12 additional uses
                     return ((double) trade.getMaxUses() - trade.getCurrentUses()) / 12;
                 return 1 - (trade.getCurrentUses() / (double) (trade.getMaxUses()));
-            });
-        Flow wholeRow = new Row().coverChildren()
+            }, null));
+        Flow wholeRow = Flow.row()
+            .coverChildren()
             .padding(1)
             .childPadding(2)
             .child(inputItems)

--- a/src/main/java/com/fouristhenumber/utilitiesinexcess/compat/mui/tradingpost/TradeWidget.java
+++ b/src/main/java/com/fouristhenumber/utilitiesinexcess/compat/mui/tradingpost/TradeWidget.java
@@ -15,6 +15,7 @@ import com.cleanroommc.modularui.theme.WidgetThemeEntry;
 import com.cleanroommc.modularui.utils.Color;
 import com.cleanroommc.modularui.value.ObjectValue;
 import com.cleanroommc.modularui.widget.ParentWidget;
+import com.cleanroommc.modularui.widget.Widget;
 import com.cleanroommc.modularui.widgets.ProgressWidget;
 import com.cleanroommc.modularui.widgets.layout.Flow;
 import com.cleanroommc.modularui.widgets.layout.Row;
@@ -73,22 +74,29 @@ public class TradeWidget extends ParentWidget<TradeWidget> implements Interactab
             .displayAmount(true)
             .item(new ObjectValue.Dynamic<>(() -> this.recipe != null ? this.recipe.getItemToBuy() : item, i -> {}));
 
-        itemToBuy2 = new TooltipItemDisplayWidget();
-        itemToBuy2.paddingLeft(0)
-            .displayAmount(true)
-            .item(
-                new ObjectValue.Dynamic<>(
-                    () -> this.recipe != null ? this.recipe.getSecondItemToBuy() : item,
-                    i -> {}));
+        Flow inputItems = new Row().childPadding(1)
+            .coverChildren()
+            .child(itemToBuy);
+
+        if (this.recipe.getSecondItemToBuy() != null) {
+            itemToBuy2 = new TooltipItemDisplayWidget();
+            itemToBuy2.paddingLeft(0)
+                .displayAmount(true)
+                .item(
+                    new ObjectValue.Dynamic<>(
+                        () -> this.recipe != null ? this.recipe.getSecondItemToBuy() : item,
+                        i -> {}));
+
+            inputItems.child(itemToBuy2);
+        } else {
+            inputItems.child(new Widget<>().size(18));
+            itemToBuy2 = null;
+        }
 
         itemToSell = new TooltipItemDisplayWidget();
         itemToSell.displayAmount(true)
             .item(new ObjectValue.Dynamic<>(() -> this.recipe != null ? this.recipe.getItemToSell() : item, i -> {}));
 
-        Flow inputItems = new Row().childPadding(1)
-            .coverChildren()
-            .child(itemToBuy)
-            .child(itemToBuy2);
         ProgressWidget progress = new TradeProgressWidget().direction(ProgressWidget.Direction.RIGHT)
             .texture(GuiTextures.PROGRESS_ARROW, 20)
             .progress(() -> {
@@ -180,6 +188,7 @@ public class TradeWidget extends ParentWidget<TradeWidget> implements Interactab
     }
 
     public boolean matches(String search) {
-        return itemToBuy.matches(search) || itemToBuy2.matches(search) || itemToSell.matches(search);
+        return itemToBuy.matches(search) || (itemToBuy2 != null && itemToBuy2.matches(search))
+            || itemToSell.matches(search);
     }
 }

--- a/src/main/java/com/fouristhenumber/utilitiesinexcess/compat/mui/tradingpost/VillagerSyncHandler.java
+++ b/src/main/java/com/fouristhenumber/utilitiesinexcess/compat/mui/tradingpost/VillagerSyncHandler.java
@@ -35,6 +35,7 @@ public class VillagerSyncHandler extends SyncHandler {
         this.column = column;
         this.data = data;
         this.recipeList = recipeList;
+        this.allowC2S();
 
         this.recipeList.setFavorites(getFavorites());
     }
@@ -225,9 +226,9 @@ public class VillagerSyncHandler extends SyncHandler {
                 price1slots.add(i);
             } else if (ItemStack.areItemStackTagsEqual(itemStack, price2) && price2 != null
                 && itemStack.isItemEqual(price2)) {
-                    count2 += itemStack.stackSize;
-                    price2slots.add(i);
-                }
+                count2 += itemStack.stackSize;
+                price2slots.add(i);
+            }
         }
 
         // How many times can we pay the first item

--- a/src/main/java/com/fouristhenumber/utilitiesinexcess/compat/mui/tradingpost/VillagerSyncHandler.java
+++ b/src/main/java/com/fouristhenumber/utilitiesinexcess/compat/mui/tradingpost/VillagerSyncHandler.java
@@ -226,9 +226,9 @@ public class VillagerSyncHandler extends SyncHandler {
                 price1slots.add(i);
             } else if (ItemStack.areItemStackTagsEqual(itemStack, price2) && price2 != null
                 && itemStack.isItemEqual(price2)) {
-                count2 += itemStack.stackSize;
-                price2slots.add(i);
-            }
+                    count2 += itemStack.stackSize;
+                    price2slots.add(i);
+                }
         }
 
         // How many times can we pay the first item

--- a/src/main/java/com/fouristhenumber/utilitiesinexcess/compat/mui/tradingpost/VillagerSyncHandler.java
+++ b/src/main/java/com/fouristhenumber/utilitiesinexcess/compat/mui/tradingpost/VillagerSyncHandler.java
@@ -35,6 +35,7 @@ public class VillagerSyncHandler extends SyncHandler {
         this.column = column;
         this.data = data;
         this.recipeList = recipeList;
+        this.allowC2S();
 
         this.recipeList.setFavorites(getFavorites());
     }

--- a/src/main/java/com/fouristhenumber/utilitiesinexcess/compat/mui/tradingpost/VillagerWidget.java
+++ b/src/main/java/com/fouristhenumber/utilitiesinexcess/compat/mui/tradingpost/VillagerWidget.java
@@ -9,16 +9,17 @@ import net.minecraft.entity.passive.EntityVillager;
 import net.minecraft.village.MerchantRecipe;
 import net.minecraft.village.MerchantRecipeList;
 
+import com.cleanroommc.modularui.api.GuiAxis;
 import com.cleanroommc.modularui.api.widget.IWidget;
 import com.cleanroommc.modularui.drawable.GuiTextures;
 import com.cleanroommc.modularui.factory.PosGuiData;
 import com.cleanroommc.modularui.value.sync.PanelSyncManager;
 import com.cleanroommc.modularui.value.sync.SyncHandler;
-import com.cleanroommc.modularui.widgets.layout.Column;
+import com.cleanroommc.modularui.widgets.layout.Flow;
 import com.fouristhenumber.utilitiesinexcess.common.tileentities.TileEntityTradingPost;
 import com.fouristhenumber.utilitiesinexcess.common.wrappers.MerchantRecipeListWrapper;
 
-public class VillagerWidget extends Column {
+public class VillagerWidget extends Flow {
 
     private final PosGuiData data;
     private final PanelSyncManager manager;
@@ -32,7 +33,7 @@ public class VillagerWidget extends Column {
 
     public VillagerWidget(PosGuiData data, PanelSyncManager manager, IMerchant merchant,
         VillagerColumn villagerColumn) {
-        super();
+        super(GuiAxis.Y);
         this.data = data;
         this.manager = manager;
         background(GuiTextures.BUTTON_CLEAN);


### PR DESCRIPTION
This adresses/closes [Issue 142](https://github.com/GTNewHorizons/UtilitiesInExcess/issues/142).

It now tests for a second recipe. If there is no second recipe available the item display is replaced by a empty widget.

I added `this.allowC2S();` to `VillagerSyncHandler.java`, not sure if it was just forgotten or if it adds unforeseen consequences I'm not aware of.