### PR TITLE
Added flammability to flammable blocks

### DIFF
--- a/src/main/java/com/fouristhenumber/utilitiesinexcess/common/blocks/BlockBlackoutCurtains.java
+++ b/src/main/java/com/fouristhenumber/utilitiesinexcess/common/blocks/BlockBlackoutCurtains.java
@@ -81,4 +81,14 @@ public class BlockBlackoutCurtains extends Block {
     public boolean canConnectTo(IBlockAccess world, int x, int y, int z, ForgeDirection dir) {
         return canConnectToBlock(world.getBlock(x, y, z)) || world.isSideSolid(x, y, z, dir.getOpposite(), false);
     }
+
+    @Override
+    public int getFlammability(IBlockAccess world, int x, int y, int z, ForgeDirection face) {
+        return 60;
+    }
+
+    @Override
+    public int getFireSpreadSpeed(IBlockAccess world, int x, int y, int z, ForgeDirection face) {
+        return 30;
+    }
 }

--- a/src/main/java/com/fouristhenumber/utilitiesinexcess/common/blocks/BlockColored.java
+++ b/src/main/java/com/fouristhenumber/utilitiesinexcess/common/blocks/BlockColored.java
@@ -12,6 +12,7 @@ import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.StatCollector;
 import net.minecraft.world.IBlockAccess;
+import net.minecraftforge.common.util.ForgeDirection;
 
 import com.fouristhenumber.utilitiesinexcess.mixins.early.minecraft.accessors.AccessorBlock;
 import com.fouristhenumber.utilitiesinexcess.mixins.early.minecraft.accessors.AccessorBlock_Client;
@@ -69,6 +70,16 @@ public class BlockColored extends Block {
     public int colorMultiplier(IBlockAccess worldIn, int x, int y, int z) {
         int meta = worldIn.getBlockMetadata(x, y, z);
         return ColorUtils.getHexColorFromWoolMeta(meta);
+    }
+
+    @Override
+    public int getFlammability(IBlockAccess world, int x, int y, int z, ForgeDirection face) {
+        return base.getFlammability(world, x, y, z, face);
+    }
+
+    @Override
+    public int getFireSpreadSpeed(IBlockAccess world, int x, int y, int z, ForgeDirection face) {
+        return base.getFireSpreadSpeed(world, x, y, z, face);
     }
 
     @SideOnly(Side.CLIENT)

--- a/src/main/java/com/fouristhenumber/utilitiesinexcess/common/blocks/BlockCompressed.java
+++ b/src/main/java/com/fouristhenumber/utilitiesinexcess/common/blocks/BlockCompressed.java
@@ -11,6 +11,8 @@ import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.IIcon;
 import net.minecraft.util.StatCollector;
+import net.minecraft.world.IBlockAccess;
+import net.minecraftforge.common.util.ForgeDirection;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
@@ -90,5 +92,15 @@ public class BlockCompressed extends Block {
                     getUnlocalizedName() + ".desc",
                     (long) Math.pow(9, stack.getItemDamage() + 1)));
         }
+    }
+
+    @Override
+    public int getFlammability(IBlockAccess world, int x, int y, int z, ForgeDirection face) {
+        return this.base.getFlammability(world, x, y, z, face) / 2;
+    }
+
+    @Override
+    public int getFireSpreadSpeed(IBlockAccess world, int x, int y, int z, ForgeDirection face) {
+        return this.base.getFireSpreadSpeed(world, x, y, z, face) / 2;
     }
 }

--- a/src/main/java/com/fouristhenumber/utilitiesinexcess/common/blocks/BlockMagicWood.java
+++ b/src/main/java/com/fouristhenumber/utilitiesinexcess/common/blocks/BlockMagicWood.java
@@ -2,7 +2,9 @@ package com.fouristhenumber.utilitiesinexcess.common.blocks;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
+import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
+import net.minecraftforge.common.util.ForgeDirection;
 
 public class BlockMagicWood extends Block {
 
@@ -19,5 +21,15 @@ public class BlockMagicWood extends Block {
     @Override
     public float getEnchantPowerBonus(World world, int x, int y, int z) {
         return 5.0f;
+    }
+
+    @Override
+    public int getFlammability(IBlockAccess world, int x, int y, int z, ForgeDirection face) {
+        return 5;
+    }
+
+    @Override
+    public int getFireSpreadSpeed(IBlockAccess world, int x, int y, int z, ForgeDirection face) {
+        return 5;
     }
 }

--- a/src/main/java/com/fouristhenumber/utilitiesinexcess/common/blocks/BlockPacifistsBench.java
+++ b/src/main/java/com/fouristhenumber/utilitiesinexcess/common/blocks/BlockPacifistsBench.java
@@ -3,7 +3,9 @@ package com.fouristhenumber.utilitiesinexcess.common.blocks;
 import net.minecraft.block.BlockContainer;
 import net.minecraft.block.material.Material;
 import net.minecraft.tileentity.TileEntity;
+import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
+import net.minecraftforge.common.util.ForgeDirection;
 
 import com.fouristhenumber.utilitiesinexcess.common.tileentities.TileEntityPacifistsBench;
 
@@ -23,5 +25,15 @@ public class BlockPacifistsBench extends BlockContainer {
     @Override
     public TileEntity createNewTileEntity(World worldIn, int meta) {
         return new TileEntityPacifistsBench();
+    }
+
+    @Override
+    public int getFlammability(IBlockAccess world, int x, int y, int z, ForgeDirection face) {
+        return 5;
+    }
+
+    @Override
+    public int getFireSpreadSpeed(IBlockAccess world, int x, int y, int z, ForgeDirection face) {
+        return 10;
     }
 }

--- a/src/main/java/com/fouristhenumber/utilitiesinexcess/common/blocks/BlockSoundMuffler.java
+++ b/src/main/java/com/fouristhenumber/utilitiesinexcess/common/blocks/BlockSoundMuffler.java
@@ -10,7 +10,9 @@ import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.StatCollector;
+import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
+import net.minecraftforge.common.util.ForgeDirection;
 
 import com.fouristhenumber.utilitiesinexcess.common.tileentities.TileEntitySoundMuffler;
 import com.fouristhenumber.utilitiesinexcess.config.blocks.BlockConfig;
@@ -62,5 +64,15 @@ public class BlockSoundMuffler extends BlockContainer {
                     "tile.sound_muffler.desc.2",
                     BlockConfig.soundMuffler.soundMufflerReduction));
         }
+    }
+
+    @Override
+    public int getFlammability(IBlockAccess world, int x, int y, int z, ForgeDirection face) {
+        return 30;
+    }
+
+    @Override
+    public int getFireSpreadSpeed(IBlockAccess world, int x, int y, int z, ForgeDirection face) {
+        return 30;
     }
 }

--- a/src/main/java/com/fouristhenumber/utilitiesinexcess/common/blocks/BlockSpike.java
+++ b/src/main/java/com/fouristhenumber/utilitiesinexcess/common/blocks/BlockSpike.java
@@ -15,7 +15,9 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.util.IIcon;
+import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
+import net.minecraftforge.common.util.ForgeDirection;
 
 import com.fouristhenumber.utilitiesinexcess.common.tileentities.TileEntitySpike;
 import com.google.common.collect.Multimap;
@@ -101,6 +103,24 @@ public class BlockSpike extends Block {
         }
 
         super.breakBlock(world, x, y, z, block, meta);
+    }
+
+    @Override
+    public int getFlammability(IBlockAccess world, int x, int y, int z, ForgeDirection face) {
+        if (spikeType == SpikeType.WOOD) {
+            return 20;
+        } else {
+            return 0;
+        }
+    }
+
+    @Override
+    public int getFireSpreadSpeed(IBlockAccess world, int x, int y, int z, ForgeDirection face) {
+        if (spikeType == SpikeType.WOOD) {
+            return 5;
+        } else {
+            return 0;
+        }
     }
 
     // Drop the cached ItemStack

--- a/src/main/java/com/fouristhenumber/utilitiesinexcess/common/blocks/BlockTradingPost.java
+++ b/src/main/java/com/fouristhenumber/utilitiesinexcess/common/blocks/BlockTradingPost.java
@@ -8,6 +8,7 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
+import net.minecraftforge.common.util.ForgeDirection;
 
 import com.cleanroommc.modularui.factory.GuiFactories;
 import com.fouristhenumber.utilitiesinexcess.common.tileentities.TileEntityTradingPost;
@@ -60,5 +61,15 @@ public class BlockTradingPost extends BlockContainer {
     @Override
     public IIcon getIcon(IBlockAccess worldIn, int x, int y, int z, int side) {
         return getIcon(side, 0);
+    }
+
+    @Override
+    public int getFlammability(IBlockAccess world, int x, int y, int z, ForgeDirection face) {
+        return 5;
+    }
+
+    @Override
+    public int getFireSpreadSpeed(IBlockAccess world, int x, int y, int z, ForgeDirection face) {
+        return 5;
     }
 }


### PR DESCRIPTION
Closes [Issue 162](https://github.com/GTNewHorizons/UtilitiesInExcess/issues/162)

- Spikes burn if out of wood
- Colored blocks inherit from base block
- Compressed blocks also inherit from base, but burn double as long and spread half as fast
- Didn't make chest flammable due to the normal chest also not being flammable

Also added flammability to:
- Trading post
- Rain and sound muffler
- Blackout curtains
- Magic Wood
- Pacifist bench