### PR TITLE
Fix generators consuming non fuel items

### DIFF
--- a/src/main/java/com/fouristhenumber/utilitiesinexcess/common/tileentities/generators/TileEntityBaseGeneratorWithItemFuel.java
+++ b/src/main/java/com/fouristhenumber/utilitiesinexcess/common/tileentities/generators/TileEntityBaseGeneratorWithItemFuel.java
@@ -95,7 +95,8 @@ public abstract class TileEntityBaseGeneratorWithItemFuel extends TileEntityBase
     @Override
     protected boolean consumeFuel() {
         if (fuelStack != null && fuelStack.getItem() != null
-            && energyStorage.getEnergyStored() < energyStorage.getMaxEnergyStored()) {
+            && energyStorage.getEnergyStored() < energyStorage.getMaxEnergyStored()
+            && isItemValidForSlot(0, fuelStack)) {
             currentFuelBurnTime = getFuelBurnTime(fuelStack);
             currentRFPerTick = getRFPerTick(fuelStack);
             fuelStack.stackSize--;


### PR DESCRIPTION
When you put a lava bucket into a furnace generator it turns into a regular bucket, that the generator will consume for no reason