### PR TITLE
Creative QOL pass

### DIFF
--- a/src/main/java/com/fouristhenumber/utilitiesinexcess/common/blocks/BlockBedrockium.java
+++ b/src/main/java/com/fouristhenumber/utilitiesinexcess/common/blocks/BlockBedrockium.java
@@ -4,6 +4,7 @@ import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemStack;
 import net.minecraft.potion.Potion;
@@ -34,7 +35,8 @@ public class BlockBedrockium extends Block {
 
         @Override
         public void onUpdate(ItemStack stack, World worldIn, Entity entityIn, int p_77663_4_, boolean p_77663_5_) {
-            if (entityIn instanceof EntityLivingBase entity) {
+            if (entityIn instanceof EntityLivingBase entity
+                && !(entity instanceof EntityPlayer player && player.capabilities.isCreativeMode)) {
                 entity.addPotionEffect(new PotionEffect(Potion.moveSlowdown.id, 0, 3, true));
             }
         }

--- a/src/main/java/com/fouristhenumber/utilitiesinexcess/common/blocks/BlockDrum.java
+++ b/src/main/java/com/fouristhenumber/utilitiesinexcess/common/blocks/BlockDrum.java
@@ -117,7 +117,9 @@ public class BlockDrum extends BlockContainer implements IBlockColor {
             FluidStack drained = heldItem.drain(stack, accepted, false);
             if (drained == null || drained.amount != accepted) return false;
 
-            heldItem.drain(stack, accepted, true);
+            if (!player.capabilities.isCreativeMode) {
+                heldItem.drain(stack, accepted, true);
+            }
             if (heldItemStack.stackSize > 1) {
                 giveResultStack(player, heldItemStack, stack);
             }
@@ -137,7 +139,9 @@ public class BlockDrum extends BlockContainer implements IBlockColor {
             toTransfer.amount = accepted;
 
             drum.drain(ForgeDirection.UP, accepted, true);
-            heldItem.fill(heldItemStack, toTransfer, true);
+            if (!player.capabilities.isCreativeMode) {
+                heldItem.fill(heldItemStack, toTransfer, true);
+            }
 
         }
         return true;
@@ -150,12 +154,14 @@ public class BlockDrum extends BlockContainer implements IBlockColor {
         int accepted = drum.fill(ForgeDirection.UP, containerFluid, false);
         if (accepted != containerFluid.amount) return false;
 
-        ItemStack emptyContainer = FluidContainerRegistry.drainFluidContainer(heldItem);
-        if (emptyContainer == null) return false;
+        if (!player.capabilities.isCreativeMode) {
+            ItemStack emptyContainer = FluidContainerRegistry.drainFluidContainer(heldItem);
+            if (emptyContainer == null) return false;
+
+            giveResultStack(player, heldItem, emptyContainer);
+        }
 
         drum.fill(ForgeDirection.UP, containerFluid, true);
-
-        giveResultStack(player, heldItem, emptyContainer);
 
         return true;
     }
@@ -175,7 +181,9 @@ public class BlockDrum extends BlockContainer implements IBlockColor {
 
         drum.drain(ForgeDirection.UP, simDrain.amount, true);
 
-        giveResultStack(player, heldItem, filledContainer);
+        if (!player.capabilities.isCreativeMode) {
+            giveResultStack(player, heldItem, filledContainer);
+        }
 
         return true;
     }

--- a/src/main/java/com/fouristhenumber/utilitiesinexcess/common/items/ItemBedrockiumIngot.java
+++ b/src/main/java/com/fouristhenumber/utilitiesinexcess/common/items/ItemBedrockiumIngot.java
@@ -2,6 +2,7 @@ package com.fouristhenumber.utilitiesinexcess.common.items;
 
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.potion.Potion;
@@ -12,7 +13,8 @@ public class ItemBedrockiumIngot extends Item {
 
     @Override
     public void onUpdate(ItemStack stack, World worldIn, Entity entityIn, int p_77663_4_, boolean p_77663_5_) {
-        if (entityIn instanceof EntityLivingBase entity) {
+        if (entityIn instanceof EntityLivingBase entity
+            && !(entity instanceof EntityPlayer player && player.capabilities.isCreativeMode)) {
             entity.addPotionEffect(new PotionEffect(Potion.moveSlowdown.id, 0, 3, true));
         }
     }

--- a/src/main/java/com/fouristhenumber/utilitiesinexcess/common/items/ItemChunchunmaru.java
+++ b/src/main/java/com/fouristhenumber/utilitiesinexcess/common/items/ItemChunchunmaru.java
@@ -3,7 +3,6 @@ package com.fouristhenumber.utilitiesinexcess.common.items;
 import java.util.List;
 
 import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.ItemSword;
 import net.minecraft.potion.Potion;
@@ -70,9 +69,8 @@ public class ItemChunchunmaru extends ItemSword implements ITranslucentItem {
 
         @SubscribeEvent
         public static void onAttackEntity(AttackEntityEvent event) {
-            if (ChunchunmaruConfig.damageCreativePlayers && event.target instanceof EntityPlayerMP tp
-                && tp.theItemInWorldManager.isCreative()
-                && event.entity instanceof EntityPlayer player
+            if (ChunchunmaruConfig.damageCreativePlayers && event.entity instanceof EntityPlayer player
+                && player.capabilities.isCreativeMode
                 && player.getHeldItem()
                     .getItem() instanceof ItemChunchunmaru) {
                 boolean isCrit = player.fallDistance > 0.0F && !player.onGround

--- a/src/main/java/com/fouristhenumber/utilitiesinexcess/common/items/ItemMobJar.java
+++ b/src/main/java/com/fouristhenumber/utilitiesinexcess/common/items/ItemMobJar.java
@@ -82,8 +82,10 @@ public class ItemMobJar extends Item {
                     entity.setPosition(targetX, targetY, targetZ);
 
                     world.spawnEntityInWorld(entity);
-                    stack.getTagCompound()
-                        .removeTag("MobData");
+                    if (!player.capabilities.isCreativeMode || player.isSneaking()) {
+                        stack.getTagCompound()
+                            .removeTag("MobData");
+                    }
                 }
             }
             return true;

--- a/src/main/java/com/fouristhenumber/utilitiesinexcess/config/items/ItemConfig.java
+++ b/src/main/java/com/fouristhenumber/utilitiesinexcess/config/items/ItemConfig.java
@@ -36,6 +36,9 @@ public class ItemConfig {
     @Config.DefaultInt(49)
     public static int superArchitectsWandBuildLimit;
 
+    @Config.DefaultInt(200)
+    public static int architectsWandCreativeBuildLimit;
+
     @Config.DefaultInt(100)
     @Config.Comment("[GT5U] Durability damage dealt to Trowels per block placed by the Architect's Wand. (Set to 0 to disable)")
     public static int damageTrowelWithArchitectsWand;

--- a/src/main/java/com/fouristhenumber/utilitiesinexcess/utils/ArchitectsSelection.java
+++ b/src/main/java/com/fouristhenumber/utilitiesinexcess/utils/ArchitectsSelection.java
@@ -73,10 +73,8 @@ public class ArchitectsSelection {
     }
 
     public int maxPlaceCount(EntityPlayer player, int wandLimit) {
-        if (player.capabilities.isCreativeMode) {
-            if (player.isSneaking()) return wandLimit;
-            return ItemConfig.architectsWandCreativeBuildLimit;
-        }
+        if (player.capabilities.isCreativeMode) return ItemConfig.architectsWandCreativeBuildLimit;
+
         int count = 0;
         for (ItemStack block : blockToPlace(player)) {
             count += ArchitectsWandUtils.countItemInInventory(player, block);

--- a/src/main/java/com/fouristhenumber/utilitiesinexcess/utils/ArchitectsSelection.java
+++ b/src/main/java/com/fouristhenumber/utilitiesinexcess/utils/ArchitectsSelection.java
@@ -16,6 +16,7 @@ import net.minecraft.world.World;
 import org.jetbrains.annotations.Nullable;
 
 import com.fouristhenumber.utilitiesinexcess.compat.Mods;
+import com.fouristhenumber.utilitiesinexcess.config.items.ItemConfig;
 import com.gtnewhorizon.gtnhlib.blockpos.BlockPos;
 
 import gregtech.api.items.MetaGeneratedTool;
@@ -72,7 +73,10 @@ public class ArchitectsSelection {
     }
 
     public int maxPlaceCount(EntityPlayer player, int wandLimit) {
-        if (player.capabilities.isCreativeMode) return wandLimit;
+        if (player.capabilities.isCreativeMode) {
+            if (player.isSneaking()) return wandLimit;
+            return ItemConfig.architectsWandCreativeBuildLimit;
+        }
         int count = 0;
         for (ItemStack block : blockToPlace(player)) {
             count += ArchitectsWandUtils.countItemInInventory(player, block);


### PR DESCRIPTION
In creative:
 - bedrockium doesn't slow you down when held
 - you can fill and drain drums without affecting your held item
 - you can empty the mob jar without affecting your held item (lets creative players easily duplicate mobs)
 - the architect's wand has a larger block count