### PR TITLE
Make heavenly ring implement ITranslucentItem

### DIFF
--- a/src/main/java/com/fouristhenumber/utilitiesinexcess/common/items/ItemHeavenlyRing.java
+++ b/src/main/java/com/fouristhenumber/utilitiesinexcess/common/items/ItemHeavenlyRing.java
@@ -20,6 +20,7 @@ import net.minecraftforge.common.util.FakePlayer;
 
 import com.fouristhenumber.utilitiesinexcess.compat.Mods;
 import com.fouristhenumber.utilitiesinexcess.config.items.ItemConfig;
+import com.gtnewhorizon.gtnhlib.api.ITranslucentItem;
 import com.gtnewhorizon.gtnhlib.eventbus.EventBusSubscriber;
 
 import baubles.api.BaubleType;
@@ -32,7 +33,7 @@ import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
 @Optional.Interface(iface = "baubles.api.IBauble", modid = "Baubles")
-public class ItemHeavenlyRing extends Item implements IBauble {
+public class ItemHeavenlyRing extends Item implements IBauble, ITranslucentItem {
 
     private final int RING_COUNT;
     private final String SUFFIX;


### PR DESCRIPTION
No one will ever notice this, but the magic ring has alpha pixels
Before:
<img width="1497" height="643" alt="image" src="https://github.com/user-attachments/assets/5fa614a5-ecfe-4ea9-8d6a-8379182d05b2" />
After:
<img width="1397" height="645" alt="image" src="https://github.com/user-attachments/assets/d5921b84-94b3-4ada-af55-554a0a5fc131" />
