### PR TITLE
Allow Architect's Wand to replace fluid

### DIFF
--- a/src/main/java/com/fouristhenumber/utilitiesinexcess/utils/ArchitectsWandUtils.java
+++ b/src/main/java/com/fouristhenumber/utilitiesinexcess/utils/ArchitectsWandUtils.java
@@ -174,10 +174,6 @@ public class ArchitectsWandUtils {
 
                 Block block = Block.getBlockFromItem(itemStackToPlace.getItem());
                 return selection.matches(currentBlock)
-                    && world.isAirBlock(
-                        targetLocation.x + clickedSide.offsetX,
-                        targetLocation.y + clickedSide.offsetY,
-                        targetLocation.z + clickedSide.offsetZ)
                     && block.canPlaceBlockOnSide(
                         world,
                         targetLocation.x + clickedSide.offsetX,

--- a/src/main/java/com/fouristhenumber/utilitiesinexcess/utils/ArchitectsWandUtils.java
+++ b/src/main/java/com/fouristhenumber/utilitiesinexcess/utils/ArchitectsWandUtils.java
@@ -74,7 +74,7 @@ public class ArchitectsWandUtils {
 
     /**
      * Finds the blocks adjacent to the start position that are connected cardinally, or diagonally
-     * and have air in front of them relative to the side clicked on.
+     * and have a placeable block (e.g. air, fluid) in front of them relative to the side clicked on.
      *
      * @param world               The world in which to place
      * @param findCount           The maximum amount of blocks it should search


### PR DESCRIPTION
This air check is unnecessary and overly restrictive, placement is already verified by canPlaceBlockOnSide

Closes https://github.com/GTNewHorizons/UtilitiesInExcess/issues/245
 
## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [ ] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md):

no i used ten billion zillion mythos tokens to write this pr and i didnt read the code either

- [ ] This PR requires another PR in order to merge
