### PR TITLE
Glove SimpleSkinBackport compat

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -49,6 +49,7 @@ dependencies {
     compileOnly('com.github.GTNewHorizons:GT5-Unofficial:5.09.54.12:dev')
     compileOnly("com.github.GTNewHorizons:waila:1.19.30:dev")
     compileOnly("com.github.GTNewHorizons:Postea:1.2.5:dev") {transitive = false}
+    compileOnly("com.github.GTNewHorizons:SimpleSkinBackport:1.0.2-GTNH:dev") {transitive = false}
 
     devOnlyNonPublishable("com.github.GTNewHorizons:Baubles-Expanded:2.2.21-GTNH:dev")
     devOnlyNonPublishable("io.github.legacymoddingmc:unimixins:0.1.23:dev")

--- a/src/main/java/com/fouristhenumber/utilitiesinexcess/ClientProxy.java
+++ b/src/main/java/com/fouristhenumber/utilitiesinexcess/ClientProxy.java
@@ -15,6 +15,7 @@ import com.fouristhenumber.utilitiesinexcess.compat.ForgeMultipart.FMPItems;
 import com.fouristhenumber.utilitiesinexcess.compat.ForgeMultipart.render.item.ItemUEMultiPartRenderer;
 import com.fouristhenumber.utilitiesinexcess.compat.Mods;
 import com.fouristhenumber.utilitiesinexcess.compat.findit.FindItHelper;
+import com.fouristhenumber.utilitiesinexcess.compat.simpleskinbackport.SsbCompat;
 import com.fouristhenumber.utilitiesinexcess.compat.waila.TTRenderUIETimeLeftBar;
 import com.fouristhenumber.utilitiesinexcess.render.CollectorRangeBox;
 import com.fouristhenumber.utilitiesinexcess.render.ISBRHUnderworldPortal;
@@ -80,6 +81,9 @@ public class ClientProxy extends CommonProxy {
         super.postInit(event);
         if (Mods.Waila.isLoaded()) {
             TTRenderUIETimeLeftBar.register();
+        }
+        if (Mods.SimpleSkinBackport.isLoaded()) {
+            SsbCompat.init();
         }
     }
 }

--- a/src/main/java/com/fouristhenumber/utilitiesinexcess/common/renderers/GloveRenderer.java
+++ b/src/main/java/com/fouristhenumber/utilitiesinexcess/common/renderers/GloveRenderer.java
@@ -1,5 +1,7 @@
 package com.fouristhenumber.utilitiesinexcess.common.renderers;
 
+import java.util.function.Function;
+
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.ScaledResolution;
 import net.minecraft.client.renderer.RenderHelper;
@@ -107,39 +109,59 @@ public class GloveRenderer implements IItemRenderer {
         new float[][] { { 8, 8, 16, 16 }, { 8, 8, 16, 16 }, { 0, 16, 8, 18 }, { 0, 16, 8, 18 }, { 0, 16, 8, 18 },
             { 0, 16, 8, 18 } });
 
+    public static final RenderableCube topCubeSlim = new RenderableCube(
+        0.21,
+        0,
+        0,
+        1,
+        1,
+        1,
+        new float[][] { { 16, 8, 24, 16 }, { 8, 8, 16, 16 }, { 3, 8, 8, 16 }, { 11, 0, 16, 8 }, { 0, 0, 8, 8 },
+            { 16, 0, 24, 8 } });
+
+    public static final RenderableCube bottomCubeSlim = new RenderableCube(
+        0.21,
+        0,
+        0,
+        1,
+        0.25,
+        1,
+        new float[][] { { 8, 8, 16, 16 }, { 8, 8, 16, 16 }, { 3, 16, 8, 18 }, { 3, 16, 8, 18 }, { 0, 16, 8, 18 },
+            { 0, 16, 8, 18 } });
+
     public static final ResourceLocation gloveTexture = new ResourceLocation(
         "utilitiesinexcess",
         "textures/items/glove_model.png");
 
-    public static void renderGloveAsBauble(int meta) {
+    public static Function<EntityPlayer, RenderableCube> getTopCube = (player) -> topCube;
+
+    public static Function<EntityPlayer, RenderableCube> getBottomCube = (player) -> bottomCube;
+
+    public static void renderGloveAsBauble(int meta, EntityPlayer player) {
         int previousTex = GL11.glGetInteger(GL11.GL_TEXTURE_BINDING_2D);
 
         // 0.27 -0.73 1.43 -0.5 0 0 0 1
         Minecraft mc = Minecraft.getMinecraft();
-        GL11.glScalef(0.27F, 0.27F, 0.27F);
-        GL11.glTranslatef(-0.73F, 1.43F, -0.5F);
-
-        GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
-        GL11.glEnable(GL11.GL_BLEND);
-        GL11.glEnable(GL11.GL_ALPHA_TEST);
+        GL11.glScalef(0.285F, 0.285F, 0.285F);
+        GL11.glTranslatef(-0.72F, 1.43F, -0.5F);
 
         mc.renderEngine.bindTexture(gloveTexture);
         Tessellator t = Tessellator.instance;
         float[] rgb = woolMetaToRGB(meta / 16);
         t.startDrawingQuads();
         t.setColorOpaque_F(rgb[0], rgb[1], rgb[2]);
-        topCube.draw(t, 0, 0, 0, 24, false);
+        getTopCube.apply(player)
+            .draw(t, 0, 0, 0, 24, false);
         t.draw();
 
         GL11.glTranslatef(0, -0.25F, 0F);
         rgb = woolMetaToRGB(meta % 16);
         t.startDrawingQuads();
         t.setColorOpaque_F(rgb[0], rgb[1], rgb[2]);
-        bottomCube.draw(t, 0, 0, 0, 24, false);
+        getBottomCube.apply(player)
+            .draw(t, 0, 0, 0, 24, false);
         t.draw();
 
-        GL11.glDisable(GL11.GL_BLEND);
-        GL11.glDisable(GL11.GL_ALPHA_TEST);
         GL11.glBindTexture(GL11.GL_TEXTURE_2D, previousTex);
     }
 

--- a/src/main/java/com/fouristhenumber/utilitiesinexcess/compat/Mods.java
+++ b/src/main/java/com/fouristhenumber/utilitiesinexcess/compat/Mods.java
@@ -19,7 +19,8 @@ public enum Mods {
     Postea("postea"),
     ForgeMicroBlock("ForgeMicroblock"),
     Backhand("backhand"),
-    GT("gregtech_nh")
+    GT("gregtech_nh"),
+    SimpleSkinBackport("simpleskinbackport")
     ;
     // spotless:on
 

--- a/src/main/java/com/fouristhenumber/utilitiesinexcess/compat/simpleskinbackport/SsbCompat.java
+++ b/src/main/java/com/fouristhenumber/utilitiesinexcess/compat/simpleskinbackport/SsbCompat.java
@@ -1,0 +1,23 @@
+package com.fouristhenumber.utilitiesinexcess.compat.simpleskinbackport;
+
+import com.fouristhenumber.utilitiesinexcess.common.renderers.GloveRenderer;
+
+import roadhog360.simpleskinbackport.ducks.IArmsState;
+
+public class SsbCompat {
+
+    public static void init() {
+        GloveRenderer.getTopCube = (player) -> {
+            if (((IArmsState) player).ssb$isSlim()) {
+                return GloveRenderer.topCubeSlim;
+            }
+            return GloveRenderer.topCube;
+        };
+        GloveRenderer.getBottomCube = (player) -> {
+            if (((IArmsState) player).ssb$isSlim()) {
+                return GloveRenderer.bottomCubeSlim;
+            }
+            return GloveRenderer.bottomCube;
+        };
+    }
+}

--- a/src/main/java/com/fouristhenumber/utilitiesinexcess/mixins/early/minecraft/MixinModelBiped_Baubles.java
+++ b/src/main/java/com/fouristhenumber/utilitiesinexcess/mixins/early/minecraft/MixinModelBiped_Baubles.java
@@ -31,8 +31,7 @@ public class MixinModelBiped_Baubles {
             value = "INVOKE",
             target = "Lnet/minecraft/client/model/ModelRenderer;render(F)V",
             shift = At.Shift.AFTER,
-            ordinal = 6),
-        remap = false)
+            ordinal = 6))
     private void uie$render1(Entity p_78088_1_, float p_78088_2_, float p_78088_3_, float p_78088_4_, float p_78088_5_,
         float p_78088_6_, float p_78088_7_, CallbackInfo ci) {
         uie$doExtraRender(p_78088_1_, p_78088_7_);
@@ -44,8 +43,7 @@ public class MixinModelBiped_Baubles {
             value = "INVOKE",
             target = "Lnet/minecraft/client/model/ModelRenderer;render(F)V",
             shift = At.Shift.AFTER,
-            ordinal = 13),
-        remap = false)
+            ordinal = 13))
     private void uie$render2(Entity p_78088_1_, float p_78088_2_, float p_78088_3_, float p_78088_4_, float p_78088_5_,
         float p_78088_6_, float p_78088_7_, CallbackInfo ci) {
         uie$doExtraRender(p_78088_1_, p_78088_7_);
@@ -53,12 +51,11 @@ public class MixinModelBiped_Baubles {
 
     private float uie$heavenlyRingWing = 1;
 
-    private void uie$doExtraRender(Entity p_78088_1_, float p_78088_7_) {
+    private void uie$doExtraRender(Entity entity, float p_78088_7_) {
         ModelBiped thisObject = (ModelBiped) (Object) this;
 
-        if (p_78088_1_ == null) return;
-        if (!(p_78088_1_ instanceof EntityPlayer)) return;
-        EntityPlayer player = (EntityPlayer) p_78088_1_;
+        if (entity == null) return;
+        if (!(entity instanceof EntityPlayer player)) return;
 
         ItemStack stack = player.getHeldItem();
         if (stack == null || !(stack.getItem() instanceof ItemGlove))
@@ -69,7 +66,7 @@ public class MixinModelBiped_Baubles {
             ModelPartRenderHelper.renderBipedPart(
                 0.0625F,
                 thisObject.bipedRightArm,
-                () -> GloveRenderer.renderGloveAsBauble(finalStack.getItemDamage()));
+                () -> GloveRenderer.renderGloveAsBauble(finalStack.getItemDamage(), player));
         }
 
         ItemStack ring = ItemHeavenlyRing.wingedPlayers.getOrDefault(player, null);

--- a/src/main/java/com/fouristhenumber/utilitiesinexcess/mixins/early/minecraft/MixinModelRenderer_Baubles.java
+++ b/src/main/java/com/fouristhenumber/utilitiesinexcess/mixins/early/minecraft/MixinModelRenderer_Baubles.java
@@ -22,8 +22,7 @@ public class MixinModelRenderer_Baubles {
         at = @At(
             value = "INVOKE",
             target = "Lnet/minecraft/client/model/ModelRenderer;render(F)V",
-            shift = At.Shift.AFTER),
-        remap = false)
+            shift = At.Shift.AFTER))
     private void uie$renderFirstPersonArm(EntityPlayer player, CallbackInfo ci) {
         RenderPlayer thisObject = (RenderPlayer) (Object) this;
 
@@ -38,7 +37,7 @@ public class MixinModelRenderer_Baubles {
             ModelPartRenderHelper.renderBipedPart(
                 0.0625F,
                 thisObject.modelBipedMain.bipedRightArm,
-                () -> GloveRenderer.renderGloveAsBauble(finalStack.getItemDamage()));
+                () -> GloveRenderer.renderGloveAsBauble(finalStack.getItemDamage(), player));
         }
     }
 }


### PR DESCRIPTION
Removes `remap = false` that causes bauble renders to not work (honestly no idea why I put it there)
Makes gloves slightly bigger to cover second skin layer
Makes gloves smaller if the player uses a slim skin
<img width="287" height="268" alt="image" src="https://github.com/user-attachments/assets/edcb65cc-a082-4da9-ab77-95e21d5da2c2" /> <img width="542" height="496" alt="image" src="https://github.com/user-attachments/assets/6c2c32ee-2198-4316-90d7-9307615b6544" />


## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
