### PR TITLE
Check held item for heavenly ring wing render

### DIFF
--- a/src/main/java/com/fouristhenumber/utilitiesinexcess/mixins/early/minecraft/MixinModelBiped_Baubles.java
+++ b/src/main/java/com/fouristhenumber/utilitiesinexcess/mixins/early/minecraft/MixinModelBiped_Baubles.java
@@ -69,11 +69,13 @@ public class MixinModelBiped_Baubles {
                 () -> GloveRenderer.renderGloveAsBauble(finalStack.getItemDamage(), player));
         }
 
-        ItemStack ring = ItemHeavenlyRing.wingedPlayers.getOrDefault(player, null);
-        if (ring == null && player.getHeldItem() != null
-            && player.getHeldItem()
-                .getItem() instanceof ItemHeavenlyRing) {
+        ItemStack ring = null;
+        if (player.getHeldItem() != null && player.getHeldItem()
+            .getItem() instanceof ItemHeavenlyRing) {
             ring = player.getHeldItem();
+        }
+        if (ring == null) {
+            ItemHeavenlyRing.wingedPlayers.getOrDefault(player, null);
         }
         if (ring == null) {
             ring = UIEUtils.getBauble(player, ItemHeavenlyRing.class);

--- a/src/main/java/com/fouristhenumber/utilitiesinexcess/mixins/early/minecraft/MixinModelBiped_Baubles.java
+++ b/src/main/java/com/fouristhenumber/utilitiesinexcess/mixins/early/minecraft/MixinModelBiped_Baubles.java
@@ -70,6 +70,11 @@ public class MixinModelBiped_Baubles {
         }
 
         ItemStack ring = ItemHeavenlyRing.wingedPlayers.getOrDefault(player, null);
+        if (ring == null && player.getHeldItem() != null
+            && player.getHeldItem()
+                .getItem() instanceof ItemHeavenlyRing) {
+            ring = player.getHeldItem();
+        }
         if (ring == null) {
             ring = UIEUtils.getBauble(player, ItemHeavenlyRing.class);
         }


### PR DESCRIPTION
This makes selecting wings easier, since before (with baubles enabled) you couldn't actually see which wings you were on without equipping the ring

Checklist
✅ I have tested this PR in DevEnv
❌ I have tested this PR in Fullpack
✅ This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
❌ This PR requires another PR in order to merge