### PR TITLE
Chore: Consolidate waila compat registration into WailaCompat

### DIFF
--- a/src/main/java/com/fouristhenumber/utilitiesinexcess/CommonProxy.java
+++ b/src/main/java/com/fouristhenumber/utilitiesinexcess/CommonProxy.java
@@ -77,12 +77,6 @@ public class CommonProxy {
         ARCHITECTS_KEYBIND_V = SyncedKeybind
             .createFromMC(() -> () -> Minecraft.getMinecraft().gameSettings.keyBindSprint);
         ModTileEntities.init();
-        if (Mods.Waila.isLoaded()) {
-            FMLInterModComms.sendMessage(
-                "Waila",
-                "register",
-                "com.fouristhenumber.utilitiesinexcess.compat.waila.WailaHandler.callbackRegister");
-        }
     }
 
     public void postInit(FMLPostInitializationEvent event) {

--- a/src/main/java/com/fouristhenumber/utilitiesinexcess/compat/waila/TTRenderColoredBlock.java
+++ b/src/main/java/com/fouristhenumber/utilitiesinexcess/compat/waila/TTRenderColoredBlock.java
@@ -19,8 +19,10 @@ import mcp.mobius.waila.overlay.OverlayConfig;
 public class TTRenderColoredBlock implements IWailaTooltipRenderer {
 
     public static void register() {
-        ModuleRegistrar.instance()
-            .registerTooltipRenderer("waila.uie.coloredblock", new TTRenderColoredBlock());
+        if (BlockColored.allowDyingBlocks()) {
+            ModuleRegistrar.instance()
+                .registerTooltipRenderer("waila.uie.coloredblock", new TTRenderColoredBlock());
+        }
     }
 
     private String string;

--- a/src/main/java/com/fouristhenumber/utilitiesinexcess/compat/waila/VoidQuarryDataProvider.java
+++ b/src/main/java/com/fouristhenumber/utilitiesinexcess/compat/waila/VoidQuarryDataProvider.java
@@ -8,42 +8,19 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
 
-import com.fouristhenumber.utilitiesinexcess.CommonProxy;
 import com.fouristhenumber.utilitiesinexcess.common.tileentities.TileEntityVoidMarker;
 import com.fouristhenumber.utilitiesinexcess.common.tileentities.TileEntityVoidQuarry;
 
 import mcp.mobius.waila.api.IWailaConfigHandler;
 import mcp.mobius.waila.api.IWailaDataAccessor;
 import mcp.mobius.waila.api.IWailaDataProvider;
-import mcp.mobius.waila.api.IWailaRegistrar;
 import mcp.mobius.waila.api.SpecialChars;
 import mcp.mobius.waila.cbcore.LangUtil;
 
-/**
- * Registered in {@link CommonProxy} via IMC.
- */
-public class WailaHandler implements IWailaDataProvider {
+public class VoidQuarryDataProvider implements IWailaDataProvider {
 
-    public static void callbackRegister(IWailaRegistrar registrar) {
-        WailaHandler instance = new WailaHandler();
-        registrar.registerBodyProvider(instance, TileEntityVoidQuarry.class);
-        registrar.registerNBTProvider(instance, TileEntityVoidQuarry.class);
-        registrar.registerBodyProvider(instance, TileEntityVoidMarker.class);
-        registrar.registerNBTProvider(instance, TileEntityVoidMarker.class);
-    }
+    public static VoidQuarryDataProvider INSTANCE = new VoidQuarryDataProvider();
 
-    @Override
-    public ItemStack getWailaStack(IWailaDataAccessor accessor, IWailaConfigHandler config) {
-        return null;
-    }
-
-    @Override
-    public List<String> getWailaHead(ItemStack itemStack, List<String> currenttip, IWailaDataAccessor accessor,
-        IWailaConfigHandler config) {
-        return currenttip;
-    }
-
-    @Override
     public List<String> getWailaBody(ItemStack itemStack, List<String> currenttip, IWailaDataAccessor accessor,
         IWailaConfigHandler config) {
         if (accessor.getTileEntity() instanceof TileEntityVoidQuarry) {
@@ -78,18 +55,26 @@ public class WailaHandler implements IWailaDataProvider {
         return currenttip;
     }
 
-    @Override
-    public List<String> getWailaTail(ItemStack itemStack, List<String> currenttip, IWailaDataAccessor accessor,
-        IWailaConfigHandler config) {
-        return currenttip;
-    }
-
-    @Override
     public NBTTagCompound getNBTData(EntityPlayerMP player, TileEntity te, NBTTagCompound tag, World world, int x,
         int y, int z) {
         if (te != null) {
             te.writeToNBT(tag);
         }
         return tag;
+    }
+
+    // Stubs
+    public ItemStack getWailaStack(IWailaDataAccessor accessor, IWailaConfigHandler config) {
+        return null;
+    }
+
+    public List<String> getWailaHead(ItemStack itemStack, List<String> currenttip, IWailaDataAccessor accessor,
+        IWailaConfigHandler config) {
+        return currenttip;
+    }
+
+    public List<String> getWailaTail(ItemStack itemStack, List<String> currenttip, IWailaDataAccessor accessor,
+        IWailaConfigHandler config) {
+        return currenttip;
     }
 }

--- a/src/main/java/com/fouristhenumber/utilitiesinexcess/compat/waila/WailaCompat.java
+++ b/src/main/java/com/fouristhenumber/utilitiesinexcess/compat/waila/WailaCompat.java
@@ -7,6 +7,8 @@ import com.fouristhenumber.utilitiesinexcess.common.blocks.BlockRainMuffler;
 import com.fouristhenumber.utilitiesinexcess.common.blocks.BlockSmartPump;
 import com.fouristhenumber.utilitiesinexcess.common.blocks.BlockSpike;
 import com.fouristhenumber.utilitiesinexcess.common.blocks.generators.BlockBaseGenerator;
+import com.fouristhenumber.utilitiesinexcess.common.tileentities.TileEntityVoidMarker;
+import com.fouristhenumber.utilitiesinexcess.common.tileentities.TileEntityVoidQuarry;
 
 import mcp.mobius.waila.api.IWailaDataProvider;
 import mcp.mobius.waila.api.IWailaRegistrar;
@@ -30,6 +32,13 @@ public class WailaCompat {
 
         registrar.registerBodyProvider(RainMufflerDataProvider.INSTANCE, BlockRainMuffler.class);
 
-        registrar.registerBodyProvider(ColoredBlocksDataProvider.INSTANCE, BlockColored.class);
+        registrar.registerBodyProvider(VoidQuarryDataProvider.INSTANCE, TileEntityVoidQuarry.class);
+        registrar.registerNBTProvider(VoidQuarryDataProvider.INSTANCE, TileEntityVoidQuarry.class);
+        registrar.registerBodyProvider(VoidQuarryDataProvider.INSTANCE, TileEntityVoidMarker.class);
+        registrar.registerNBTProvider(VoidQuarryDataProvider.INSTANCE, TileEntityVoidMarker.class);
+
+        if (BlockColored.allowDyingBlocks()) {
+            registrar.registerBodyProvider(ColoredBlocksDataProvider.INSTANCE, BlockColored.class);
+        }
     }
 }


### PR DESCRIPTION
Been meaning to get around to this since void quarry got merged
Definitely not because I forgot the `allowDyingBlocks` checks.

Checklist
✅ I have tested this PR in DevEnv
❌ I have tested this PR in Fullpack
✅ This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
❌ This PR requires another PR in order to merge