### PR TITLE
fixed builders wand item matching - check NBT as well

### DIFF
--- a/src/main/java/com/fouristhenumber/utilitiesinexcess/utils/BuildersWandUtils.java
+++ b/src/main/java/com/fouristhenumber/utilitiesinexcess/utils/BuildersWandUtils.java
@@ -28,7 +28,19 @@ public class BuildersWandUtils {
 
     public BuildersWandUtils() {}
 
-    ;
+    /**
+     * ItemStacks match based on
+     * -> item type
+     * -> item damage
+     * -> item NBT
+     * <p>
+     * (Some mods use NBT data in BlockItem instead of metadata to keep track of the exact type,
+     * e.g. ArchitectureCraft Shapes -> need to distinguish between different shapes of the same block)
+     *
+     */
+    private static boolean matchesExactly(ItemStack a, ItemStack b) {
+        return a != null && b != null && a.isItemEqual(b) && ItemStack.areItemStackTagsEqual(a, b);
+    }
 
     /**
      * Counts the items of a certain type in a player's inventory
@@ -41,8 +53,7 @@ public class BuildersWandUtils {
         int count = 0;
 
         for (ItemStack stack : player.inventory.mainInventory) {
-            if (stack != null && stack.getItem() == itemStack.getItem()
-                && stack.getItemDamage() == itemStack.getItemDamage()) {
+            if (matchesExactly(stack, itemStack)) {
                 count += stack.stackSize;
             }
         }
@@ -60,8 +71,7 @@ public class BuildersWandUtils {
     public static boolean decreaseFromInventory(EntityPlayer player, ItemStack itemStack) {
         for (int slotIndex = player.inventory.mainInventory.length - 1; slotIndex >= 0; slotIndex--) {
             ItemStack stack = player.inventory.mainInventory[slotIndex];
-            if (stack != null && stack.getItem() == itemStack.getItem()
-                && stack.getItemDamage() == itemStack.getItemDamage()) {
+            if (matchesExactly(stack, itemStack)) {
                 stack.stackSize -= 1;
                 if (stack.stackSize <= 0) {
                     player.inventory.setInventorySlotContents(slotIndex, null);

--- a/src/main/java/com/fouristhenumber/utilitiesinexcess/utils/BuildersWandUtils.java
+++ b/src/main/java/com/fouristhenumber/utilitiesinexcess/utils/BuildersWandUtils.java
@@ -20,6 +20,7 @@ import net.minecraftforge.common.util.ForgeDirection;
 
 import com.fouristhenumber.utilitiesinexcess.compat.Mods;
 import com.gtnewhorizon.gtnhlib.blockpos.BlockPos;
+import com.gtnewhorizon.gtnhlib.util.ItemUtil;
 
 import gregtech.api.items.MetaGeneratedTool;
 import xonin.backhand.api.core.BackhandUtils;
@@ -27,20 +28,6 @@ import xonin.backhand.api.core.BackhandUtils;
 public class BuildersWandUtils {
 
     public BuildersWandUtils() {}
-
-    /**
-     * ItemStacks match based on
-     * -> item type
-     * -> item damage
-     * -> item NBT
-     * <p>
-     * (Some mods use NBT data in BlockItem instead of metadata to keep track of the exact type,
-     * e.g. ArchitectureCraft Shapes -> need to distinguish between different shapes of the same block)
-     *
-     */
-    private static boolean matchesExactly(ItemStack a, ItemStack b) {
-        return a != null && b != null && a.isItemEqual(b) && ItemStack.areItemStackTagsEqual(a, b);
-    }
 
     /**
      * Counts the items of a certain type in a player's inventory
@@ -53,7 +40,7 @@ public class BuildersWandUtils {
         int count = 0;
 
         for (ItemStack stack : player.inventory.mainInventory) {
-            if (matchesExactly(stack, itemStack)) {
+            if (ItemUtil.areStacksEqual(stack, itemStack)) {
                 count += stack.stackSize;
             }
         }
@@ -71,7 +58,7 @@ public class BuildersWandUtils {
     public static boolean decreaseFromInventory(EntityPlayer player, ItemStack itemStack) {
         for (int slotIndex = player.inventory.mainInventory.length - 1; slotIndex >= 0; slotIndex--) {
             ItemStack stack = player.inventory.mainInventory[slotIndex];
-            if (matchesExactly(stack, itemStack)) {
+            if (ItemUtil.areStacksEqual(stack, itemStack)) {
                 stack.stackSize -= 1;
                 if (stack.stackSize <= 0) {
                     player.inventory.setInventorySlotContents(slotIndex, null);


### PR DESCRIPTION
## Problem
Current behavior of BuildersWand uses first `world.getBlock(x, y, z).getPickBlock` to correctly extract the full itemstack from the block it copies, then tries to find that block inside the players inventory. However this lookup checks only item and damage, disregarding NBT. This is a problem for mods that save their state inside TileEntity NBT such as ArchitectureCrafts Shape blocks. 
This results in a case where wand allows placing a shape block as long as there is **ANY** shape block in the inventory regardless of the "type".   
(Notice the non-matching shape block in the players slot still allows for the block placement:)
<img width="854" height="480" alt="2026-08-06_13 38 57" src="https://github.com/user-attachments/assets/3db09fb2-112c-4228-b691-b139185ffc7c" />

## Solution
This fix simply adds the NBT check.

## Addendum
I've actually written an ExtraUtilities mixin for this case, with some additional features, which I believe would fit the UiE as well but thats for another ticket....

[https://github.com/Cooble/XUWandModes.git](https://github.com/Cooble/XUWandModes.git)
