### PR TITLE
Fix crash with disabled blocks in FMPCompat

### DIFF
--- a/src/main/java/com/fouristhenumber/utilitiesinexcess/compat/ForgeMultipart/FMPCompat.java
+++ b/src/main/java/com/fouristhenumber/utilitiesinexcess/compat/ForgeMultipart/FMPCompat.java
@@ -87,9 +87,9 @@ public class FMPCompat {
     }
 
     private static void registerMicroblock(ModBlocks block, int meta) {
-        String blockName = GameRegistry.findUniqueIdentifierFor(block.get())
-            .toString();
         if (block.isEnabled()) {
+            String blockName = GameRegistry.findUniqueIdentifierFor(block.get())
+                .toString();
             MicroMaterialRegistry
                 .registerMaterial(new BlockMicroMaterial(block.get(), meta), applyMeta(blockName, meta));
         }


### PR DESCRIPTION
## Summary
block.get() was called outside of .isEnabled guard, so it crashed if you were running FMP and disabled blocks in config.

Closes https://github.com/GTNewHorizons/UtilitiesInExcess/issues/300

## Checklist
- [ ] I have tested this PR in DevEnv
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
