### PR TITLE
Fix Mystcraft crash with BiomeDecoratorUnderworld

### DIFF
--- a/src/main/java/com/fouristhenumber/utilitiesinexcess/common/dimensions/underworld/BiomeDecoratorUnderWorld.java
+++ b/src/main/java/com/fouristhenumber/utilitiesinexcess/common/dimensions/underworld/BiomeDecoratorUnderWorld.java
@@ -9,6 +9,7 @@ import static net.minecraftforge.event.terraingen.OreGenEvent.GenerateMinable.Ev
 
 import net.minecraft.world.WorldServer;
 import net.minecraft.world.biome.BiomeDecorator;
+import net.minecraft.world.chunk.IChunkProvider;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.terraingen.OreGenEvent;
 import net.minecraftforge.event.terraingen.TerrainGen;
@@ -17,9 +18,8 @@ public class BiomeDecoratorUnderWorld extends BiomeDecorator {
 
     @Override
     protected void generateOres() {
-        double difficulty = getChunkProvider().getDifficulty(chunk_X, chunk_Z);
 
-        boolean isAggressiveArea = difficulty >= 2;
+        boolean isAggressiveArea = getDifficulty() >= 2;
 
         MinecraftForge.ORE_GEN_BUS.post(new OreGenEvent.Pre(currentWorld, randomGenerator, chunk_X, chunk_Z));
 
@@ -54,7 +54,11 @@ public class BiomeDecoratorUnderWorld extends BiomeDecorator {
         MinecraftForge.ORE_GEN_BUS.post(new OreGenEvent.Post(currentWorld, randomGenerator, chunk_X, chunk_Z));
     }
 
-    private ChunkProviderUnderWorld getChunkProvider() {
-        return (ChunkProviderUnderWorld) ((WorldServer) currentWorld).theChunkProviderServer.currentChunkProvider;
+    private double getDifficulty() {
+        IChunkProvider chunkProvider = ((WorldServer) currentWorld).theChunkProviderServer.currentChunkProvider;
+        if (chunkProvider instanceof ChunkProviderUnderWorld chunkProviderUnderWorld) {
+            return chunkProviderUnderWorld.getDifficulty(chunk_X, chunk_Z);
+        }
+        return 1;
     }
 }


### PR DESCRIPTION
## Summary
Fix https://github.com/GTNewHorizons/UtilitiesInExcess/issues/299. Handle BiomeDecoratorUnderworld being called from a non-ChunkProviderUnderworld, return sensible difficulty default of 1.


## Checklist
- [ ] I have tested this PR in DevEnv
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
