### PR TITLE
Improve MineTweaker integration

### DIFF
--- a/src/main/java/com/fouristhenumber/utilitiesinexcess/api/EnderLocusRegistry.java
+++ b/src/main/java/com/fouristhenumber/utilitiesinexcess/api/EnderLocusRegistry.java
@@ -1,6 +1,8 @@
 package com.fouristhenumber.utilitiesinexcess.api;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Predicate;
 
 import net.minecraft.block.Block;
 import net.minecraft.inventory.InventoryCrafting;
@@ -90,8 +92,23 @@ public final class EnderLocusRegistry {
         }
     }
 
-    public void removeRecipe(ItemStack output) {
-        this.recipes.removeIf(recipe -> ItemStack.areItemStacksEqual(recipe.getOutput(), output));
+    public List<EnderLocusRecipe> removeRecipes(Predicate<EnderLocusRecipe> test) {
+        ArrayList<EnderLocusRecipe> removed = new ArrayList<>(3);
+
+        this.recipes.removeIf(recipe -> {
+            if (test.test(recipe)) {
+                removed.add(recipe);
+                return true;
+            } else {
+                return false;
+            }
+        });
+
+        return removed;
+    }
+
+    public void removeRecipe(EnderLocusRecipe recipe) {
+        this.recipes.remove(recipe);
     }
 
     public ItemStack findRecipe(InventoryCrafting inv, boolean consume) {

--- a/src/main/java/com/fouristhenumber/utilitiesinexcess/compat/crafttweaker/EnderLocusCraftTweakerSupport.java
+++ b/src/main/java/com/fouristhenumber/utilitiesinexcess/compat/crafttweaker/EnderLocusCraftTweakerSupport.java
@@ -1,8 +1,12 @@
 package com.fouristhenumber.utilitiesinexcess.compat.crafttweaker;
 
+import java.util.List;
+import java.util.Objects;
+
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.StatCollector;
-import net.minecraftforge.oredict.OreDictionary;
+
+import org.jetbrains.annotations.Nullable;
 
 import com.fouristhenumber.utilitiesinexcess.UtilitiesInExcess;
 import com.fouristhenumber.utilitiesinexcess.api.EnderLocusRecipe;
@@ -10,7 +14,6 @@ import com.fouristhenumber.utilitiesinexcess.api.EnderLocusRegistry;
 
 import minetweaker.IUndoableAction;
 import minetweaker.MineTweakerAPI;
-import minetweaker.OneWayAction;
 import minetweaker.annotations.ModOnly;
 import minetweaker.api.item.IIngredient;
 import minetweaker.api.item.IItemStack;
@@ -24,84 +27,163 @@ public class EnderLocusCraftTweakerSupport {
 
     @ZenMethod
     public static void addRecipe(IItemStack output, IIngredient[][] inputs) {
-        MineTweakerAPI.apply(new IUndoableAction() {
+        final EnderLocusRecipe recipe = parseRecipe(output, inputs);
+        if (recipe == null) return;
 
-            private boolean successful = false;
-
-            @Override
-            public void apply() {
-                Object[] inputArray = new Object[9];
-
-                for (int row = 0; row < 3; row++) {
-                    for (int col = 0; col < 3; col++) {
-                        IIngredient input = inputs[row][col];
-                        if (input == null) {
-                            inputArray[row * 3 + col] = null;
-                            continue;
-                        }
-
-                        Object rawInput = input.getInternal();
-                        if (rawInput instanceof ItemStack stack) {
-                            inputArray[row * 3 + col] = stack;
-                        } else if (rawInput instanceof String ore) {
-                            inputArray[row * 3 + col] = OreDictionary.getOres(ore)
-                                .toArray(new ItemStack[0]);
-                        }
-                    }
-                }
-
-                EnderLocusRegistry.instance()
-                    .addRecipe(new EnderLocusRecipe(inputArray, MineTweakerMC.getItemStack(output)));
-                successful = true;
-            }
-
-            @Override
-            public boolean canUndo() {
-                return successful;
-            }
-
-            @Override
-            public void undo() {
-                EnderLocusRegistry.instance()
-                    .removeRecipe(MineTweakerMC.getItemStack(output));
-            }
-
-            @Override
-            public String describe() {
-                return "Adding Ender Locus recipe for " + StatCollector.translateToLocal(output.getName());
-            }
-
-            @Override
-            public String describeUndo() {
-                return "Undoing Ender Locus recipe addition for " + StatCollector.translateToLocal(output.getName());
-            }
-
-            @Override
-            public Object getOverrideKey() {
-                return null;
-            }
-        });
+        MineTweakerAPI.apply(new ActionAddLocusRecipe(recipe));
     }
 
     @ZenMethod
     public static void removeRecipe(IItemStack output) {
-        MineTweakerAPI.apply(new OneWayAction() {
+        MineTweakerAPI.apply(new ActionRemoveLocusRecipes(output));
+    }
 
-            @Override
-            public void apply() {
+    private static @Nullable EnderLocusRecipe parseRecipe(IItemStack output, IIngredient[][] inputs) {
+        Object[] inputArray = new Object[9];
+        boolean hasInput = false;
+
+        if (inputs.length != 3 || inputs[0].length != 3 || inputs[1].length != 3 || inputs[2].length != 3) {
+            MineTweakerAPI.logError("Ender Locus recipe must be provided a 3x3 grid of input elements");
+            return null;
+        }
+
+        for (int row = 0; row < 3; row++) {
+            for (int col = 0; col < 3; col++) {
+                IIngredient ingredient = inputs[row][col];
+                if (ingredient == null) continue;
+
+                List<IItemStack> stacks = ingredient.getItems();
+                if (stacks == null || stacks.size() == 0) {
+                    MineTweakerAPI.logError("Unsupported ingredient for Ender Locus recipe: " + ingredient);
+                    return null;
+                }
+
+                // Note: getItemStack can only fail if other mods add their own implementation of IItemStack.
+                if (stacks.size() == 1) {
+                    ItemStack input = MineTweakerMC.getItemStack(stacks.get(0));
+                    if (input == null) return null;
+
+                    inputArray[row * 3 + col] = input;
+                } else {
+                    ItemStack[] input = stacks.stream()
+                        .map(MineTweakerMC::getItemStack)
+                        .filter(Objects::nonNull)
+                        .toArray(ItemStack[]::new);
+
+                    if (input.length == 0) return null;
+
+                    inputArray[row * 3 + col] = input;
+                }
+
+                hasInput = true;
+            }
+        }
+
+        if (!hasInput) {
+            MineTweakerAPI.logError("Ender Locus recipe for " + output + " must have at least one ingredient.");
+            return null;
+        }
+
+        final ItemStack outStack = MineTweakerMC.getItemStack(output);
+        if (outStack == null) return null;
+
+        return new EnderLocusRecipe(inputArray, outStack);
+    }
+
+    private static class ActionAddLocusRecipe implements IUndoableAction {
+
+        private final EnderLocusRecipe recipe;
+
+        public ActionAddLocusRecipe(EnderLocusRecipe recipe) {
+            this.recipe = recipe;
+        }
+
+        @Override
+        public void apply() {
+            EnderLocusRegistry.instance()
+                .addRecipe(recipe);
+        }
+
+        @Override
+        public boolean canUndo() {
+            return true;
+        }
+
+        @Override
+        public void undo() {
+            EnderLocusRegistry.instance()
+                .removeRecipe(recipe);
+        }
+
+        @Override
+        public String describe() {
+            return "Adding Ender Locus recipe for " + StatCollector.translateToLocal(
+                recipe.getOutput()
+                    .getDisplayName());
+        }
+
+        @Override
+        public String describeUndo() {
+            return "Undoing Ender Locus recipe addition for " + StatCollector.translateToLocal(
+                recipe.getOutput()
+                    .getDisplayName());
+        }
+
+        @Override
+        public Object getOverrideKey() {
+            return null;
+        }
+    }
+
+    private static class ActionRemoveLocusRecipes implements IUndoableAction {
+
+        private EnderLocusRecipe[] removed;
+        private final IItemStack filter;
+
+        private ActionRemoveLocusRecipes(IItemStack filter) {
+            this.filter = filter;
+        }
+
+        @Override
+        public void apply() {
+            this.removed = EnderLocusRegistry.instance()
+                .removeRecipes(recipe -> {
+                    try {
+                        return filter.matchesExact(MineTweakerMC.getIItemStack(recipe.getOutput()));
+                    } catch (Exception e) {
+                        MineTweakerAPI.logError("Error while filtering Ender Locus recipes: ", e);
+                        return false;
+                    }
+                })
+                .toArray(new EnderLocusRecipe[0]);
+        }
+
+        @Override
+        public boolean canUndo() {
+            return true;
+        }
+
+        @Override
+        public void undo() {
+            for (EnderLocusRecipe recipe : this.removed) {
                 EnderLocusRegistry.instance()
-                    .removeRecipe(MineTweakerMC.getItemStack(output));
+                    .addRecipe(recipe);
             }
+        }
 
-            @Override
-            public String describe() {
-                return "Removing Ender Locus recipe for " + StatCollector.translateToLocal(output.getName());
-            }
+        @Override
+        public String describe() {
+            return "Removing Ender Locus recipe which output " + this.filter;
+        }
 
-            @Override
-            public Object getOverrideKey() {
-                return null;
-            }
-        });
+        @Override
+        public String describeUndo() {
+            return "Undoing removal of " + this.removed.length + " Ender Locus recipes which output " + this.filter;
+        }
+
+        @Override
+        public Object getOverrideKey() {
+            return null;
+        }
     }
 }

--- a/src/main/java/com/fouristhenumber/utilitiesinexcess/compat/crafttweaker/EnderLocusCraftTweakerSupport.java
+++ b/src/main/java/com/fouristhenumber/utilitiesinexcess/compat/crafttweaker/EnderLocusCraftTweakerSupport.java
@@ -33,7 +33,7 @@ public class EnderLocusCraftTweakerSupport {
     }
 
     @ZenMethod
-    public static void removeRecipe(IItemStack output) {
+    public static void removeRecipes(IItemStack output) {
         MineTweakerAPI.apply(new ActionRemoveLocusRecipes(output));
     }
 
@@ -170,12 +170,12 @@ public class EnderLocusCraftTweakerSupport {
 
         @Override
         public String describe() {
-            return "Removing Ender Locus recipe which output " + this.filter;
+            return "Removing Ender Locus recipes which output " + this.filter;
         }
 
         @Override
         public String describeUndo() {
-            return "Undoing removal of " + this.removed.length + " Ender Locus recipes which output " + this.filter;
+            return "Undoing removal of " + this.removed.length + " Ender Locus recipe(s) which output " + this.filter;
         }
 
         @Override

--- a/src/main/java/com/fouristhenumber/utilitiesinexcess/compat/crafttweaker/EnderLocusCraftTweakerSupport.java
+++ b/src/main/java/com/fouristhenumber/utilitiesinexcess/compat/crafttweaker/EnderLocusCraftTweakerSupport.java
@@ -4,7 +4,6 @@ import java.util.List;
 import java.util.Objects;
 
 import net.minecraft.item.ItemStack;
-import net.minecraft.util.StatCollector;
 
 import org.jetbrains.annotations.Nullable;
 
@@ -117,16 +116,14 @@ public class EnderLocusCraftTweakerSupport {
 
         @Override
         public String describe() {
-            return "Adding Ender Locus recipe for " + StatCollector.translateToLocal(
-                recipe.getOutput()
-                    .getDisplayName());
+            return "Adding Ender Locus recipe for " + recipe.getOutput()
+                .getDisplayName();
         }
 
         @Override
         public String describeUndo() {
-            return "Undoing Ender Locus recipe addition for " + StatCollector.translateToLocal(
-                recipe.getOutput()
-                    .getDisplayName());
+            return "Undoing Ender Locus recipe addition for " + recipe.getOutput()
+                .getDisplayName();
         }
 
         @Override


### PR DESCRIPTION
## Summary
Improve MineTweaker integration, adding extra recipe verification to `addRecipe` and making `removeRecipes` reversible.

Note: I have not yet tested these changes. I plan to hopefully add some HorizonQA tests at some point to check that these changes work as intended.


## Checklist
- [ ] I have tested this PR in DevEnv
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
